### PR TITLE
fix black trailing comma bug

### DIFF
--- a/ic3_processing/utils/exp_data/good_run_list_utils.py
+++ b/ic3_processing/utils/exp_data/good_run_list_utils.py
@@ -579,9 +579,7 @@ def get_exp_dataset_jobs(config):
                         year=year,
                         date=date,
                         run_id=run_num,
-                        # fmt: off [avoid trailing comma for <= py 3.6]
                         **get_run_info_kwargs
-                        # fmt: on [avoid trailing comma for <= py 3.6]
                     )
 
                     total_livetime += livetime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,10 @@ version = {attr = "ic3_processing.__version__"}
 
 [tool.black]
 line-length = 79
-target-version = ["py35", "py36", "py37", "py38", "py39", "py310", "py311"]
+# technically, black does not support python2.
+# This is all python versions black knows of and gets
+# rid of the trailing comma bug
+target-version = ["py33", "py34", "py35", "py36", "py37", "py38", "py39", "py310", "py311"]
 
 [tool.ruff]
 # select = ["ALL"]

--- a/resources/scripts/general_i3_processing.py
+++ b/resources/scripts/general_i3_processing.py
@@ -92,13 +92,7 @@ def main(cfg, run_number, scratch):
             tray.context["ic3_processing"]["HDF_keys"].append("DurationP")
 
         # add module
-        tray.Add(
-            module_class,
-            name,
-            # fmt: off [avoid trailing comma for <= py 3.6 compatibility]
-            **kwargs
-            # fmt: on [avoid trailing comma for <= py 3.6 compatibility]
-        )
+        tray.Add(module_class, name, **kwargs)
 
         # stop timer if specified
         if "ModuleTimer" in settings and settings["ModuleTimer"]:
@@ -160,9 +154,7 @@ def main(cfg, run_number, scratch):
             "EventWriter",
             filename="{}.{}".format(context["outfile"], cfg["i3_ending"]),
             Streams=i3_streams,
-            # fmt: off [avoid trailing comma for <= py 3.6 compatibility]
             **cfg["write_i3_kwargs"]
-            # fmt: on [avoid trailing comma for <= py 3.6 compatibility]
         )
 
     if cfg["write_hdf5"]:
@@ -173,9 +165,7 @@ def main(cfg, run_number, scratch):
             "hdf",
             Output="{}.hdf5".format(context["outfile"]),
             Keys=[k for k in set(keys)],
-            # fmt: off [avoid trailing comma for <= py 3.6 compatibility]
             **cfg["write_hdf5_kwargs"]
-            # fmt: on [avoid trailing comma for <= py 3.6 compatibility]
         )
     # --------------------------------------------------
 


### PR DESCRIPTION
This fixes what we talked about earlier today. The bug was subtle: in principle, black is aware of the trailing comma issues with python versions below 3.5, according to [this](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#trailing-commas) in its documentation. 
It employs some heuristics to determine if the python file is incompatible anyway with 3.4, and then it adds a trailing comma. If it is compatible with python 3.4, it does not add a trailing comma. 
The problem was, that we explicitly asked for compatibility in the `pyproject.toml` above 3.4 anyway. This fixes that now.