### PR TITLE
Script now returns correct exit code

### DIFF
--- a/resources/create_job_files.py
+++ b/resources/create_job_files.py
@@ -510,7 +510,7 @@ def write_job_shell_scripts(param_dict: dict, templates: List) -> str:
     wrapper_content += "   contains files.'\n"
     wrapper_content += "   fi\n"
     wrapper_content += "else\n"
-    wrapper_content += "   echo '   ...    temp_files does not exist'\n"
+    wrapper_content += "   echo '   ...    temp_step_files does not exist'\n"
     wrapper_content += "fi\n"
     wrapper_content += "exit $RET\n"
 

--- a/resources/create_job_files.py
+++ b/resources/create_job_files.py
@@ -461,7 +461,7 @@ def write_job_shell_scripts(param_dict: dict, templates: List) -> str:
         echo &&
         echo '=========================================' &&
         echo '==> Successfully processed all steps! <==' &&
-        echo '=========================================' &&
+        echo '========================================='
 
         RET=$?
         if [ $RET -ne 0 ] ; then


### PR DESCRIPTION
The ```&&``` in the line before ```RET=$?``` made the script always return 0, even if the script failed. This caused all jobs to appear as completed to dagman, even if they didn't.