### PR TITLE
Skip jobs with existing output

### DIFF
--- a/ic3_processing/cli/job_templates/cvmfs_python.sh
+++ b/ic3_processing/cli/job_templates/cvmfs_python.sh
@@ -57,7 +57,7 @@ then
             rm ${FINAL_OUT}.hdf5
         fi
         if [ "$WRITE_I3" = "True" ]; then
-            rm ${FINAL_OUT}.i3.bz2
+            rm ${FINAL_OUT}.${I3_ENDING}
         fi
         if [ -f "$FINAL_OUT" ]; then
             rm $FINAL_OUT

--- a/ic3_processing/cli/process_local.py
+++ b/ic3_processing/cli/process_local.py
@@ -200,7 +200,6 @@ def output_exists(binary):
 @click.argument(
     "path",
     type=click.Path(exists=True, resolve_path=True),
-    help="Path to directory containing the binary job files.",
 )
 @click.option("-j", "--n_jobs", default=1, help="Number of parallel jobs")
 @click.option(
@@ -223,7 +222,35 @@ def output_exists(binary):
     default=True,
     help="If False, only run jobs for which the output files are missing",
 )
-def main(path, binary_pattern, n_jobs, log_path, resume, rerun):
+def main(
+    path,
+    binary_pattern="*.sh",
+    n_jobs=1,
+    log_path=None,
+    resume=False,
+    rerun=True,
+):
+    """Process binaries locally
+
+    Parameters:
+    -----------
+    path : str
+        Path to the directory where the binaries are located.
+    binary_pattern : str, optional
+        Pattern of the binaries to be processed.
+        Default is '*.sh'.
+    n_jobs : int, optional
+        Number of parallel jobs. Default is 1.
+    log_path : str, optional
+        Path to a directory where the stdout/stderr should be saved.
+        If None is provided, no logs are saved. Default is None.
+    resume : bool, optional
+        Resume a previous run with the log files. If set to True,
+        a `log_path` must be provided. Default is False.
+    rerun : bool, optional
+        If False, only run jobs for which the output files are missing.
+        Default is True.
+    """
     path = os.path.abspath(path)
 
     log_book = JobLogBook(n_jobs=n_jobs, log_dir=log_path)

--- a/ic3_processing/cli/process_local.py
+++ b/ic3_processing/cli/process_local.py
@@ -170,8 +170,8 @@ def get_variable(file_path, variable):
         return None
 
 
-def output_exists(binary):
-    basename = os.path.basename(binary)
+def output_exists(binary, binary_pattern):
+    basename = os.path.basename(binary).replace(binary_pattern, "")
     out_dir = get_variable(binary, "OUT_DIR")
 
     # find the job file for the last step
@@ -264,7 +264,9 @@ def main(
     else:
         binaries = list(glob.glob(os.path.join(path, binary_pattern)))
         if not rerun:
-            binaries = [b for b in binaries if not output_exists(b)]
+            binaries = [
+                b for b in binaries if not output_exists(b, binary_pattern)
+            ]
         log_book.process(binaries)
 
 

--- a/ic3_processing/cli/process_local.py
+++ b/ic3_processing/cli/process_local.py
@@ -170,8 +170,8 @@ def get_variable(file_path, variable):
         return None
 
 
-def output_exists(binary, binary_pattern):
-    basename = os.path.basename(binary).replace(binary_pattern, "")
+def output_exists(binary):
+    basename = os.path.basename(binary).replace(".sh", "")
     out_dir = get_variable(binary, "OUT_DIR")
 
     # find the job file for the last step
@@ -264,9 +264,7 @@ def main(
     else:
         binaries = list(glob.glob(os.path.join(path, binary_pattern)))
         if not rerun:
-            binaries = [
-                b for b in binaries if not output_exists(b, binary_pattern)
-            ]
+            binaries = [b for b in binaries if not output_exists(b)]
         log_book.process(binaries)
 
 


### PR DESCRIPTION
Adds an option to run only those job files locally for which the output does not exist.