### PR TITLE
Add option to specify python imports

### DIFF
--- a/ic3_processing/cli/job_templates/cvmfs_python.sh
+++ b/ic3_processing/cli/job_templates/cvmfs_python.sh
@@ -9,6 +9,7 @@ WRITE_I3={write_i3}
 CUDA_HOME={cuda_home}
 LD_LIBRARY_PATH_PREPENDS={ld_library_path_prepends}
 CVMFS_PYTHON={cvmfs_python}
+PYTHON_PACKAGE_IMPORTS={python_package_imports}
 
 
 # load environment
@@ -39,6 +40,12 @@ fi
 if [ "$(echo "$LD_LIBRARY_PATH_PREPENDS" | sed 's/^.\(.*\).$/\1/')" != "ld_library_path_prepends" ]; then
   echo 'Prepending to LD_LIBRARY_PATH: '$LD_LIBRARY_PATH_PREPENDS
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_PREPENDS:$LD_LIBRARY_PATH
+fi
+
+# add additional python package imports if we have them
+if [ "$(echo "$PYTHON_PACKAGE_IMPORTS" | sed 's/^.\(.*\).$/\1/')" != "python_package_imports" ]; then
+  echo 'Importing additional python packages: '$PYTHON_PACKAGE_IMPORTS
+  export PYTHON_PACKAGE_IMPORTS
 fi
 
 # start python script

--- a/ic3_processing/cli/scripts/general_i3_processing.py
+++ b/ic3_processing/cli/scripts/general_i3_processing.py
@@ -6,6 +6,12 @@ import sys
 if "ENV_SITE_PACKAGES" in os.environ:
     sys.path.insert(1, os.environ["ENV_SITE_PACKAGES"])
 
+if "PYTHON_PACKAGE_IMPORTS" in os.environ:
+    import importlib
+
+    for package in os.environ["PYTHON_PACKAGE_IMPORTS"].split(","):
+        importlib.import_module(package)
+
 import timeit
 import click
 

--- a/resources/configs/example_i3_exp.yaml
+++ b/resources/configs/example_i3_exp.yaml
@@ -276,6 +276,10 @@ cuda_home: /data/ana/PointSource/DNNCascade/utils/cuda/cuda-10.1
 # Note: '{ld_library_path_prepends}' is the default which does not add anything
 ld_library_path_prepends: '{ld_library_path_prepends}'
 
+# add optional python packages to import as a comma separated list
+# Note: '{python_package_imports}' is the default which does not add anything
+python_package_imports: '{python_package_imports}'
+
 # Defines environment variables that are set from python
 set_env_vars_from_python: {
     'TF_DETERMINISTIC_OPS': '1',

--- a/resources/configs/example_i3_mc.yaml
+++ b/resources/configs/example_i3_mc.yaml
@@ -126,6 +126,10 @@ cuda_home: /data/ana/PointSource/DNNCascade/utils/cuda/cuda-10.1
 # Note: '{ld_library_path_prepends}' is the default which does not add anything
 ld_library_path_prepends: '{ld_library_path_prepends}'
 
+# add optional python packages to import as a comma separated list
+# Note: '{python_package_imports}' is the default which does not add anything
+python_package_imports: '{python_package_imports}'
+
 # Defines environment variables that are set from python
 set_env_vars_from_python: {
     'TF_DETERMINISTIC_OPS': '1',


### PR DESCRIPTION
Adds option to specify python packages which will be imported before building the I3Tray. This is useful if adding tray segments or modules via their name. For this to work, the underlying icecube package must be imported first, which will register the available modules. The python packages can be specified as a comma separated list via the `python_package_imports` in the configuration file.